### PR TITLE
Fix key error in watthourmeter()

### DIFF
--- a/oligo/iber.py
+++ b/oligo/iber.py
@@ -81,7 +81,7 @@ class Iber:
 
     def watthourmeter(self):
         """Returns your current power consumption."""
-        return self.measurement()['power']
+        return self.measurement()['consumption']
 
     def icpstatus(self):
         """Returns the status of your ICP."""


### PR DESCRIPTION
The function `watthourmeter` gets the key "power" from the dict returned by `measurement` but that key doesn't exist - it should be `consumption`.

This fixes [issue 12](https://github.com/hectorespert/python-oligo/issues/12)